### PR TITLE
feat: expose client to allow unref for #12

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ class KeyvRedis extends EventEmitter {
 			opts.url = opts.uri;
 		}
 
-		const client = redis.createClient(opts);
+		// expose the client so that users can .unref() for example
+		const client = this.client = redis.createClient(opts);
 
 		this.redis = ['get', 'set', 'sadd', 'del', 'srem', 'smembers'].reduce((obj, method) => {
 			obj[method] = pify(client[method].bind(client));

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,9 @@ class KeyvRedis extends EventEmitter {
 			opts.url = opts.uri;
 		}
 
-		// expose the client so that users can .unref() for example
-		const client = this.client = redis.createClient(opts);
+		// Expose the client so that users can .unref() for example
+		this.client = redis.createClient(opts);
+		const client = this.client;
 
 		this.redis = ['get', 'set', 'sadd', 'del', 'srem', 'smembers'].reduce((obj, method) => {
 			obj[method] = pify(client[method].bind(client));


### PR DESCRIPTION
Now you can do something like this to avoid preventing Node process from exiting

```js
const Keyv = require('keyv')
const keyv = new Keyv(process.env.REDIS_URL)
keyv.opts.store.client.unref()
```