### PR TITLE
build: move ioredis as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TTL functionality is handled directly by Redis so no timestamps are stored and e
 ## Install
 
 ```shell
-npm install --save keyv @keyv/redis
+npm install --save keyv @keyv/redis ioredis
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "ioredis": "4"
   },
   "peerDependencies": {
-    "ioredis": "4"
+    "ioredis": ">=4.0.0 <4.19.2 || ~4.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
     "nyc": "^14.1.1",
     "requirable": "^1.0.5",
     "this": "^1.1.0",
-    "xo": "^0.25.3"
+    "xo": "^0.25.3",
+    "ioredis": "4"
   },
   "peerDependencies": {
-    "ioredis": "~4.16.0"
+    "ioredis": "4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "url": "https://github.com/lukechilds/keyv-redis/issues"
   },
   "homepage": "https://github.com/lukechilds/keyv-redis",
-  "dependencies": {
-    "ioredis": "~4.16.0"
-  },
   "devDependencies": {
     "ava": "^2.4.0",
     "coveralls": "^3.0.7",
@@ -52,5 +49,8 @@
     "requirable": "^1.0.5",
     "this": "^1.1.0",
     "xo": "^0.25.3"
+  },
+  "peerDependencies": {
+    "ioredis": "~4.16.0"
   }
 }


### PR DESCRIPTION
Moved `ioredis` as peer dependency to avoid be locked as part of the module.

This give the same functionality plus you can control `ioredis` version out of the module.