### PR TITLE
Update redis package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/lukechilds/keyv-redis",
   "dependencies": {
     "pify": "3.0.0",
-    "redis": "2.8.0"
+    "redis": "^3.1.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Updated redis version from `2.8.0` to `3.1.2` due to dependabot security alert.